### PR TITLE
Revert MySQL version detection changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,3 +73,8 @@ This version does not exist.
 =======
 
 * Only change from upstream is suppressing the upstream update of nullable `User.last_login` (1cb5bc2).
+
+1.11.33
+=======
+
+* Revert MySQL version detection to not use `SELECT VERSION()`

--- a/django/__init__.py
+++ b/django/__init__.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.utils.version import get_version
 
-VERSION = (1, 11, 32, "alpha", 0)
+VERSION = (1, 11, 33, "alpha", 0)
 
 __version__ = get_version(VERSION)
 

--- a/django/db/backends/mysql/base.py
+++ b/django/db/backends/mysql/base.py
@@ -382,9 +382,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     @cached_property
     def mysql_version(self):
-        with self.temporary_connection() as cursor:
-            cursor.execute('SELECT VERSION()')
-            server_info = cursor.fetchone()[0]
+        with self.temporary_connection():
+            server_info = self.connection.get_server_info()
         match = server_version_re.match(server_info)
         if not match:
             raise Exception('Unable to determine MySQL version from version string %r' % server_info)


### PR DESCRIPTION
Reverts https://code.djangoproject.com/ticket/26868

We don't use MariaDB and the older way is more performant since it gets server info from the MySQL handshake packet. 

With microsecond support (which requires checking the server version), gevent, and no connection pooling on the Python side the newer version check can be very expensive for nested parallel greenlet requests.

