### PR TITLE
CPLAT-4620 patch to use collections.abc in python3

### DIFF
--- a/django/core/paginator.py
+++ b/django/core/paginator.py
@@ -121,9 +121,12 @@ class Paginator(object):
 
 
 QuerySetPaginator = Paginator   # For backwards-compatibility.
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
-
-class Page(collections.Sequence):
+class Page(Sequence):
 
     def __init__(self, object_list, number, paginator):
         self.object_list = object_list

--- a/django/db/models/sql/query.py
+++ b/django/db/models/sql/query.py
@@ -8,7 +8,13 @@ all about the internals of models in order to get the information it needs.
 """
 import copy
 import warnings
-from collections import Counter, Iterator, Mapping, OrderedDict
+from collections import Counter, OrderedDict
+try:
+    from collections.abc import Iterable
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import Iterable
+    from collections import MutableMapping
 from itertools import chain, count, product
 from string import ascii_uppercase
 


### PR DESCRIPTION
Handling the deprecation error
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```