### PR TITLE
Prevented initialization of unused database connections.

### DIFF
--- a/django/contrib/postgres/apps.py
+++ b/django/contrib/postgres/apps.py
@@ -14,7 +14,7 @@ class PostgresConfig(AppConfig):
 
     def ready(self):
         # Connections may already exist before we are called.
-        for conn in connections.all():
+        for conn in connections.all(initialized_only=True):
             if conn.connection is not None:
                 register_type_handlers(conn)
         connection_created.connect(register_type_handlers)

--- a/django/core/handlers/base.py
+++ b/django/core/handlers/base.py
@@ -108,9 +108,9 @@ class BaseHandler(object):
 
     def make_view_atomic(self, view):
         non_atomic_requests = getattr(view, '_non_atomic_requests', set())
-        for db in connections.all():
-            if db.settings_dict['ATOMIC_REQUESTS'] and db.alias not in non_atomic_requests:
-                view = transaction.atomic(using=db.alias)(view)
+        for alias, settings_dict in connections.databases.items():
+            if settings_dict.get('ATOMIC_REQUESTS', False) and alias not in non_atomic_requests:
+                view = transaction.atomic(using=alias)(view)
         return view
 
     def get_exception_response(self, request, resolver, status_code, exception):

--- a/django/db/__init__.py
+++ b/django/db/__init__.py
@@ -50,7 +50,7 @@ connection = DefaultConnectionProxy()
 
 # Register an event to reset saved queries when a Django request is started.
 def reset_queries(**kwargs):
-    for conn in connections.all():
+    for conn in connections.all(initialized_only=True):
         conn.queries_log.clear()
 
 
@@ -60,7 +60,7 @@ signals.request_started.connect(reset_queries)
 # Register an event to reset transaction state and close connections past
 # their lifetime.
 def close_old_connections(**kwargs):
-    for conn in connections.all():
+    for conn in connections.all(initialized_only=True):
         conn.close_if_unusable_or_obsolete()
 
 

--- a/django/db/utils.py
+++ b/django/db/utils.py
@@ -222,8 +222,13 @@ class ConnectionHandler(object):
     def __iter__(self):
         return iter(self.databases)
 
-    def all(self):
-        return [self[alias] for alias in self]
+    def all(self, initialized_only=False):
+        return [
+            self[alias]
+            for alias in self
+            # If initialized_only is True, return only initialized connections.
+            if not initialized_only or hasattr(self._connections, alias)
+        ]
 
     def close_all(self):
         for alias in self:

--- a/django/test/signals.py
+++ b/django/test/signals.py
@@ -62,7 +62,7 @@ def update_connections_time_zone(**kwargs):
 
     # Reset the database connections' time zone
     if kwargs['setting'] in {'TIME_ZONE', 'USE_TZ'}:
-        for conn in connections.all():
+        for conn in connections.all(initialized_only=True):
             try:
                 del conn.timezone
             except AttributeError:

--- a/django/test/testcases.py
+++ b/django/test/testcases.py
@@ -931,7 +931,7 @@ class TransactionTestCase(SimpleTestCase):
                 # tests (e.g., losing a timezone setting causing objects to be
                 # created with the wrong time). To make sure this doesn't
                 # happen, get a clean connection at the start of every test.
-                for conn in connections.all():
+                for conn in connections.all(initialized_only=True):
                     conn.close()
         finally:
             if self.available_apps is not None:
@@ -1048,7 +1048,7 @@ class TestCase(TransactionTestCase):
     def tearDownClass(cls):
         if connections_support_transactions():
             cls._rollback_atomics(cls.cls_atomics)
-            for conn in connections.all():
+            for conn in connections.all(initialized_only=True):
                 conn.close()
         super(TestCase, cls).tearDownClass()
 


### PR DESCRIPTION
Backport django/django#15490 into 1.11.x to fix high cpu usage if there's many requests and many database settings